### PR TITLE
Added tSQL specific SQL injection string

### DIFF
--- a/blns.txt
+++ b/blns.txt
@@ -586,6 +586,7 @@ http://a/%%30%30
 1'; DROP TABLE users-- 1
 ' OR 1=1 -- 1
 ' OR '1'='1
+'; EXEC sp_MSForEachTable 'DROP TABLE ?'; --
  
 %
 _


### PR DESCRIPTION
String leverages sp_MSForEachTable to be much more destructive, and breaks assumption that target has 'users' table, or any other 'table-literal'